### PR TITLE
fix : add spring security configuration

### DIFF
--- a/src/main/kotlin/com/kdongsu5509/support/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/kdongsu5509/support/config/SecurityConfig.kt
@@ -1,6 +1,6 @@
 package com.kdongsu5509.support.config
 
-import com.kdongsu5509.user.application.service.user.JwtTokenUtil
+import com.kdongsu5509.user.application.service.user.JwtAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
@@ -9,15 +9,18 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
-//TODO : change this. refer to comment of this file
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(
     securedEnabled = true,
     jsr250Enabled = true
 )
-class SecurityConfig(jwtTokenUtil: JwtTokenUtil) {
+class SecurityConfig(
+    private val securityConstants: SecurityConstants,
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter
+) {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
@@ -31,105 +34,16 @@ class SecurityConfig(jwtTokenUtil: JwtTokenUtil) {
             }
 
             authorizeHttpRequests {
-                authorize(anyRequest, permitAll)
+                // 제공된 화이트리스트 목록은 인증 없이 접근 허용
+                securityConstants.whiteListUrls.forEach { authorize(it, permitAll) }
+
+                // 그 외 모든 요청은 인증 필요
+                authorize(anyRequest, authenticated)
             }
+
+            // Spring Security의 기본 인증 필터 앞에 커스텀 JWT 필터 배치
+            addFilterBefore<UsernamePasswordAuthenticationFilter>(jwtAuthenticationFilter)
         }
         return http.build()
     }
 }
-
-//package com.kdongsu5509.imhereapigateway.filter;
-//
-//import com.kdongsu5509.imhereapigateway.filter.jwt.JwtTokenUtil;
-//import java.util.List;
-//import lombok.Getter;
-//import lombok.Setter;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.cloud.gateway.filter.GatewayFilter;
-//import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
-//import org.springframework.http.HttpHeaders;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.http.server.reactive.ServerHttpRequest;
-//import org.springframework.http.server.reactive.ServerHttpResponse;
-//import org.springframework.stereotype.Component;
-//import org.springframework.util.AntPathMatcher;
-//import org.springframework.web.server.ServerWebExchange;
-//import reactor.core.publisher.Mono;
-//
-//@Slf4j
-//@Component
-//public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<AuthorizationHeaderFilter.Config> {
-//
-//    private final JwtTokenUtil jwtTokenUtil;
-//    private final AntPathMatcher pathMatcher = new AntPathMatcher(); // 패턴 매칭용
-//
-//    public AuthorizationHeaderFilter(JwtTokenUtil jwtTokenUtil) {
-//        super(Config.class);
-//        this.jwtTokenUtil = jwtTokenUtil;
-//    }
-//
-//    @Getter
-//    @Setter
-//    public static class Config {
-//        private List<String> excludePaths; // YAML에서 받을 제외 목록
-//    }
-//
-//    @Override
-//    public GatewayFilter apply(Config config) {
-//        return (exchange, chain) -> {
-//            ServerHttpRequest request = exchange.getRequest();
-//            String path = request.getURI().getPath();
-//
-//            if (isWhiteListEndPoint(config, path)) {
-//                return chain.filter(exchange);
-//            }
-//
-//            // 2. 인증 헤더 존재 여부 확인
-//            if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
-//                return onError(exchange, "No authorization header", HttpStatus.UNAUTHORIZED);
-//            }
-//
-//            String authorizationHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
-//            String jwt = authorizationHeader.replace("Bearer ", "");
-//
-//            // 3. 토큰 유효성 검사
-//            if (!jwtTokenUtil.validateToken(jwt)) {
-//                return onError(exchange, "JWT token is not valid", HttpStatus.UNAUTHORIZED);
-//            }
-//
-//            // 4. 헤더 전파 및 필터 체인 진행
-//            return chain.filter(exchange.mutate()
-//                    .request(propagateHeader(exchange, jwt))
-//                    .build()
-//            );
-//        };
-//    }
-//
-//    private boolean isWhiteListEndPoint(Config config, String path) {
-//        if (config.getExcludePaths() != null) {
-//            for (String excludePath : config.getExcludePaths()) {
-//                if (pathMatcher.match(excludePath, path)) {
-//                    return true;
-//                }
-//            }
-//        }
-//        return false;
-//    }
-//
-//    private ServerHttpRequest propagateHeader(ServerWebExchange exchange, String jwt) {
-//        String subject = jwtTokenUtil.getUsernameFromToken(jwt);
-//        String role = jwtTokenUtil.getRoleFromToken(jwt);
-//
-//        return exchange.getRequest().mutate()
-//                .header("X-User-Email", subject)
-//                .header("X-User-Role", role)
-//                .build();
-//    }
-//
-//    private Mono<Void> onError(ServerWebExchange exchange, String err, HttpStatus httpStatus) {
-//        ServerHttpResponse response = exchange.getResponse();
-//        response.setStatusCode(httpStatus);
-//        log.error("Filter Error: {}, Status: {}", err, httpStatus);
-//        return response.setComplete();
-//    }
-//}

--- a/src/main/kotlin/com/kdongsu5509/support/config/SecurityConstants.kt
+++ b/src/main/kotlin/com/kdongsu5509/support/config/SecurityConstants.kt
@@ -1,0 +1,10 @@
+package com.kdongsu5509.support.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class SecurityConstants(
+    @field:Value(value = "\${security.whitelist}")
+    val whiteListUrls: List<String>
+)

--- a/src/main/kotlin/com/kdongsu5509/support/exception/AuthErrorCode.kt
+++ b/src/main/kotlin/com/kdongsu5509/support/exception/AuthErrorCode.kt
@@ -57,4 +57,9 @@ enum class AuthErrorCode(
         "IMHERE_TOKEN_002",
         "잘못된 토큰입니다"
     ),
+    IMHERE_ACCESS_DENIED(
+        HttpStatus.FORBIDDEN,
+        "IMHERE_TOKEN_003",
+        "해당 기능에 대한 권한이 없습니다."
+    ),
 }

--- a/src/main/kotlin/com/kdongsu5509/support/exception/ImHereGlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/kdongsu5509/support/exception/ImHereGlobalExceptionHandler.kt
@@ -4,6 +4,7 @@ import com.kdongsu5509.support.common.dto.APIResponse
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -41,6 +42,22 @@ class ImHereGlobalExceptionHandler {
                 APIResponse.fail(
                     HttpStatus.BAD_REQUEST.value(),
                     HttpStatus.BAD_REQUEST.name,
+                    errorResponse
+                )
+            )
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException::class)
+    protected fun handleAuthorizationDeniedException(e: Exception): ResponseEntity<APIResponse<ErrorResponse>> {
+        logger.error("Authorization Denied Exception occurred: ", e)
+        val errorResponse =
+            ErrorResponse(AuthErrorCode.IMHERE_ACCESS_DENIED.code, AuthErrorCode.IMHERE_ACCESS_DENIED.message)
+        return ResponseEntity
+            .status(AuthErrorCode.IMHERE_ACCESS_DENIED.status)
+            .body(
+                APIResponse.fail(
+                    HttpStatus.FORBIDDEN.value(),
+                    HttpStatus.FORBIDDEN.name,
                     errorResponse
                 )
             )

--- a/src/main/kotlin/com/kdongsu5509/user/application/service/user/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/kdongsu5509/user/application/service/user/JwtAuthenticationFilter.kt
@@ -25,8 +25,7 @@ class JwtAuthenticationFilter : OncePerRequestFilter {
     }
 
     public override fun shouldNotFilter(request: HttpServletRequest): Boolean {
-        val path = request.servletPath
-        return path.startsWith("/api/v1/auth") || path.startsWith("/actuator")
+        return request.servletPath.startsWith("/actuator")
     }
 
     public override fun doFilterInternal(

--- a/src/test/kotlin/com/kdongsu5509/user/adapter/in/web/friends/FriendsRequestReadControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/kdongsu5509/user/adapter/in/web/friends/FriendsRequestReadControllerIntegrationTest.kt
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
 import org.springframework.test.context.ActiveProfiles
@@ -94,6 +95,7 @@ class FriendsRequestReadControllerIntegrationTest {
     }
 
     @Test
+    @WithMockUser("receiver@kakao.com")
     @DisplayName("받은 친구 요청의 상세 정보를 잘 찾아 반환한다.")
     fun getReceivedRequestDetail_IntegrationSuccess() {
         //given

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -29,21 +29,11 @@ jwt:
   refresh-expiration-days: 7
   access-header-name: Authorization
 
+security:
+  whitelist: /swagger-ui/**,/v3/api-docs/**
+
 oidc:
   kakao:
     issuer: "https://kauth.kakao.com"
     audience: "bf284f33bfeba9bc59575706d0eb0e9c"
     cacheKey: "kakaoOidcKeys::kakaoPublicKeySet"
-
-    spring:
-      datasource:
-        url: jdbc:h2:mem:testdb;MODE=PostgreSQL
-        driver-class-name: org.h2.Driver
-        username: sa
-        password:
-      jpa:
-        hibernate:
-          ddl-auto: create-drop
-        properties:
-          hibernate:
-            format_sql: true


### PR DESCRIPTION
모노로틱으로 재전환하면서 누락되었던 설정 정보 재추가

# 🛠️ Related Issue / 관련 이슈

fixes #59 

---

# 📂 PR Type / PR 유형

- [ ] **Feat** (새 기능 추가)
- [x] **Fix** (버그 수정)
- [ ] **Test** (테스트 코드 추가/수정)
- [ ] **Refactor** (리팩터링 - 기능 변경 없이 코드 구조 개선)
- [ ] **Docs** (문서 수정 - README, 가이드 등)
- [ ] **Chore** (빌드 설정, 라이브러리 업데이트, 기타 유지보수)
- [ ] **Perf** (성능 개선)
- [ ] **Style** (코드 포맷, 세미콜론 등 스타일 변경)
- [ ] **Break** (Breaking Change 발생 - 후술)

---

# ✏️ Brief Description / 간단 설명

누락되었던 whitelist 정보 및 security config 정보 추가.
추가로 GlobalExceptonHandler 에 `AuthorizationDeniedException` 추가하여 403 에러가 500이 아닌 403으로 반환될 수 있도록 수정

*Please write within 100 characters.*  
*100자 이내로 작성해주세요.*
**(예시: Feat(auth): 사용자 로그인 API 연동 기능 구현)**

---

# 🔬 Changes Detail / 변경 사항 상세 내용

## 🟠 Backend (Spring Boot) 변경 사항

* **추가/변경된 주요 파일:**
- **API 변경:** (새로운 엔드포인트 또는 기존 엔드포인트 스펙 변경)
- **DB 변경:** (스키마 변경 사항, SQL 등)
- **주요 변경 내용:** (예: 비즈니스 로직 수정, 보안 설정 강화)

---

# ⚠️ Breaking Changes / 주요 변경 사항 (필수 기재)

- (내용이 있다면 여기에 작성)

---

# 🧪 Test Checklist / 테스트 체크리스트

- [ ] 로컬에서 해당 기능에 대한 수동 테스트를 완료했습니다.
- [ ] 유닛 테스트 (Unit Test) 코드를 추가/수정했습니다.
- [ ] 통합 테스트 (Integration Test) 코드를 추가/수정했습니다.
- [ ] Postman 등으로 API 동작을 확인했습니다.

---
