### PR TITLE
fix: alloy/prometheus DNS, hikari keepalive, notification failure ale…

### DIFF
--- a/docs/infra/db-schema.md
+++ b/docs/infra/db-schema.md
@@ -154,6 +154,7 @@ erDiagram
     * `ARRIVAL_CONFIRMATION`
     * `TERMS_UPDATE_NOTICE`
     * `DELIVERY_RESULT_NOTICE`
+    * `DELIVERY_FAILED_NOTICE`
 
 ### one_time_tokens
 

--- a/infra/alloy/alloy-config.alloy.template
+++ b/infra/alloy/alloy-config.alloy.template
@@ -72,10 +72,10 @@ loki.write "grafana_cloud" {
 // ---------------------------------------------------------
 
 // Spring Boot actuator 메트릭을 Docker 네트워크 내부에서 스크랩한다.
-// dsko:4861 은 호스트 공개 포트가 아니라 컨테이너 간 통신 전용이다.
+// iamhere-server-container:4861 은 호스트 공개 포트가 아니라 컨테이너 간 통신 전용이다.
 prometheus.scrape "imhere" {
 	targets = [{
-		__address__ = "dsko:4861",
+		__address__ = "iamhere-server-container:4861",
 	}]
 	scrape_interval = "30s"
 	metrics_path = "${MGMT_BASE_PATH}/prometheus"

--- a/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/AbstractNotificationConsumer.kt
+++ b/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/AbstractNotificationConsumer.kt
@@ -7,14 +7,21 @@ import com.kdongsu5509.notifications.application.port.`in`.NotificationDispatche
 import com.kdongsu5509.notifications.application.port.`in`.NotificationEnqueueUseCase
 import com.kdongsu5509.notifications.application.service.MessageIdempotencyService
 import com.kdongsu5509.notifications.domain.NotificationMethod
+import com.kdongsu5509.support.external.DiscordMessageDto
+import com.kdongsu5509.support.external.DiscordMessageSendPort
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 
 abstract class AbstractNotificationConsumer(
     private val notificationDispatcherUseCase: NotificationDispatcherUseCase,
     private val messageIdempotencyService: MessageIdempotencyService,
-    private val notificationEnqueueUseCase: NotificationEnqueueUseCase
+    private val notificationEnqueueUseCase: NotificationEnqueueUseCase,
+    private val discordMessageSendPort: DiscordMessageSendPort
 ) {
     protected val log = LoggerFactory.getLogger(javaClass)
+
+    @Value("\${discord.url.error.server:}")
+    private val errorAlertWebhookUrl: String? = null
 
     protected fun processMessage(dto: NotificationMessageDto, queueLabel: String) {
         log.info("수신된 메시지 ({}): {}", queueLabel, dto)
@@ -25,33 +32,78 @@ abstract class AbstractNotificationConsumer(
             return
         }
 
-        // 발송을 시도한다. 예외가 발생하면 markAsProcessed를 호출하지 않고 예외를 전파한다.
-        // → RabbitMQ가 NACK 처리하여 DLQ로 이동하고, 이후 replay 시 재시도할 수 있도록 의도된 설계다.
-        notificationDispatcherUseCase.dispatch(
-            NotificationCommand(
-                senderNickname = dto.sender.nickname,
-                senderEmail = dto.sender.email,
-                notificationMethod = dto.notificationMethod,
-                targetIdentifier = dto.receiver.email,
-                type = dto.category.name,
-                extraData = dto.data ?: emptyMap()
+        try {
+            // 발송을 시도한다. 예외가 발생하면 markAsProcessed를 호출하지 않고 예외를 전파한다.
+            // → RabbitMQ가 NACK 처리하여 DLQ로 이동하고, 이후 replay 시 재시도할 수 있도록 의도된 설계다.
+            notificationDispatcherUseCase.dispatch(
+                NotificationCommand(
+                    senderNickname = dto.sender.nickname,
+                    senderEmail = dto.sender.email,
+                    notificationMethod = dto.notificationMethod,
+                    targetIdentifier = dto.receiver.email,
+                    type = dto.category.name,
+                    extraData = dto.data ?: emptyMap()
+                )
             )
-        )
 
-        if (dto.category != NotificationType.DELIVERY_RESULT_NOTICE) {
+            if (dto.category !in META_NOTIFICATION_TYPES) {
+                notificationEnqueueUseCase.enqueue(
+                    NotificationCommand(
+                        senderNickname = "ImHere",
+                        senderEmail = dto.sender.email,
+                        notificationMethod = NotificationMethod.FCM,
+                        targetIdentifier = dto.sender.email,
+                        type = NotificationType.DELIVERY_RESULT_NOTICE.name,
+                        extraData = emptyMap()
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            notifyConsumerFailure(queueLabel, messageId, e)
+            notifySenderOfFailure(dto)
+            throw e
+        }
+
+        // 정상 발송 완료 후에만 처리 완료로 기록한다.
+        messageIdempotencyService.markAsProcessed(messageId)
+    }
+
+    // HTTP 요청 컨텍스트가 없는 컨슈머 스레드라 GlobalExceptionHandler/AccessLogPrinter를 못 타므로 여기서 직접 보낸다.
+    // 예외는 다시 던져 RabbitMQ NACK → DLQ 흐름을 그대로 유지한다.
+    private fun notifyConsumerFailure(queueLabel: String, messageId: String, e: Exception) {
+        errorAlertWebhookUrl?.takeIf { it.isNotEmpty() }?.let { webhookUrl ->
+            val content = """
+                ## 💥 Background Job Failure
+                **Queue:** `$queueLabel`
+                **MessageId:** `$messageId`
+                **Error:** ${e.javaClass.simpleName} - ${e.message}
+            """.trimIndent()
+            discordMessageSendPort.sendMessage(webhookUrl, DiscordMessageDto(content))
+        }
+    }
+
+    // 발송 요청자(sender)는 운영자용 Discord 알림을 볼 수 없으므로 FCM으로 실패를 알린다.
+    // 큐 등록 자체가 실패해도 원래 예외(e)를 가리면 안 되므로 여기서 삼킨다.
+    // META_NOTIFICATION_TYPES를 제외하는 이유는 실패 알림 발송이 또 실패해 무한히 재귀 발행되는 걸 막기 위함이다.
+    private fun notifySenderOfFailure(dto: NotificationMessageDto) {
+        if (dto.category in META_NOTIFICATION_TYPES) return
+
+        runCatching {
             notificationEnqueueUseCase.enqueue(
                 NotificationCommand(
                     senderNickname = "ImHere",
                     senderEmail = dto.sender.email,
                     notificationMethod = NotificationMethod.FCM,
                     targetIdentifier = dto.sender.email,
-                    type = NotificationType.DELIVERY_RESULT_NOTICE.name,
+                    type = NotificationType.DELIVERY_FAILED_NOTICE.name,
                     extraData = emptyMap()
                 )
             )
-        }
+        }.onFailure { log.error("발송 실패 알림(FCM) 큐 등록 중 오류", it) }
+    }
 
-        // 정상 발송 완료 후에만 처리 완료로 기록한다.
-        messageIdempotencyService.markAsProcessed(messageId)
+    companion object {
+        private val META_NOTIFICATION_TYPES =
+            setOf(NotificationType.DELIVERY_RESULT_NOTICE, NotificationType.DELIVERY_FAILED_NOTICE)
     }
 }

--- a/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/FriendNotificationConsumer.kt
+++ b/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/FriendNotificationConsumer.kt
@@ -5,6 +5,7 @@ import com.kdongsu5509.notifications.application.port.`in`.NotificationDispatche
 import com.kdongsu5509.notifications.application.port.`in`.NotificationEnqueueUseCase
 import com.kdongsu5509.notifications.application.service.MessageIdempotencyService
 import com.kdongsu5509.support.config.RabbitMQConfig
+import com.kdongsu5509.support.external.DiscordMessageSendPort
 import org.springframework.amqp.rabbit.annotation.RabbitListener
 import org.springframework.stereotype.Component
 
@@ -12,8 +13,9 @@ import org.springframework.stereotype.Component
 class FriendNotificationConsumer(
     notificationDispatcherUseCase: NotificationDispatcherUseCase,
     messageIdempotencyService: MessageIdempotencyService,
-    notificationEnqueueUseCase: NotificationEnqueueUseCase
-) : AbstractNotificationConsumer(notificationDispatcherUseCase, messageIdempotencyService, notificationEnqueueUseCase) {
+    notificationEnqueueUseCase: NotificationEnqueueUseCase,
+    discordMessageSendPort: DiscordMessageSendPort
+) : AbstractNotificationConsumer(notificationDispatcherUseCase, messageIdempotencyService, notificationEnqueueUseCase, discordMessageSendPort) {
     companion object {
         const val QUEUE_LABEL = "FRIEND"
     }

--- a/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/ServiceNotificationConsumer.kt
+++ b/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/ServiceNotificationConsumer.kt
@@ -5,6 +5,7 @@ import com.kdongsu5509.notifications.application.port.`in`.NotificationDispatche
 import com.kdongsu5509.notifications.application.port.`in`.NotificationEnqueueUseCase
 import com.kdongsu5509.notifications.application.service.MessageIdempotencyService
 import com.kdongsu5509.support.config.RabbitMQConfig
+import com.kdongsu5509.support.external.DiscordMessageSendPort
 import org.springframework.amqp.rabbit.annotation.RabbitListener
 import org.springframework.stereotype.Component
 
@@ -12,8 +13,9 @@ import org.springframework.stereotype.Component
 class ServiceNotificationConsumer(
     notificationDispatcherUseCase: NotificationDispatcherUseCase,
     messageIdempotencyService: MessageIdempotencyService,
-    notificationEnqueueUseCase: NotificationEnqueueUseCase
-) : AbstractNotificationConsumer(notificationDispatcherUseCase, messageIdempotencyService, notificationEnqueueUseCase) {
+    notificationEnqueueUseCase: NotificationEnqueueUseCase,
+    discordMessageSendPort: DiscordMessageSendPort
+) : AbstractNotificationConsumer(notificationDispatcherUseCase, messageIdempotencyService, notificationEnqueueUseCase, discordMessageSendPort) {
     companion object {
         const val QUEUE_LABEL = "SERVICE"
     }

--- a/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/dto/NotificationType.kt
+++ b/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/dto/NotificationType.kt
@@ -8,7 +8,8 @@ enum class NotificationType(val appPath: String) {
     DEPARTURE("/record/notifications"),
     ARRIVAL_CONFIRMATION("/record/notifications"),
     TERMS_UPDATE_NOTICE("/terms-detail/{termId}"),
-    DELIVERY_RESULT_NOTICE("/record/send-history");
+    DELIVERY_RESULT_NOTICE("/record/send-history"),
+    DELIVERY_FAILED_NOTICE("/record/send-history");
 
     companion object {
         val CLIENT_ALLOWED = setOf(

--- a/src/main/kotlin/com/kdongsu5509/notifications/adapter/out/messageQueue/NotificationRabbitMQProducerAdapter.kt
+++ b/src/main/kotlin/com/kdongsu5509/notifications/adapter/out/messageQueue/NotificationRabbitMQProducerAdapter.kt
@@ -44,6 +44,7 @@ class NotificationRabbitMQProducerAdapter(
             NotificationType.DEPARTURE -> RabbitMQConfig.ROUTING_KEY_DEPARTURE_CONFIRMATION
             NotificationType.TERMS_UPDATE_NOTICE -> RabbitMQConfig.ROUTING_KEY_TERMS_UPDATE
             NotificationType.DELIVERY_RESULT_NOTICE -> RabbitMQConfig.ROUTING_KEY_DELIVERY_RESULT
+            NotificationType.DELIVERY_FAILED_NOTICE -> RabbitMQConfig.ROUTING_KEY_DELIVERY_FAILED
         }
     }
 }

--- a/src/main/kotlin/com/kdongsu5509/notifications/application/service/NotificationMessageGenerator.kt
+++ b/src/main/kotlin/com/kdongsu5509/notifications/application/service/NotificationMessageGenerator.kt
@@ -14,6 +14,7 @@ object NotificationMessageGenerator {
             NotificationType.DEPARTURE -> "출발 안내"
             NotificationType.TERMS_UPDATE_NOTICE -> "서비스 공지사항"
             NotificationType.DELIVERY_RESULT_NOTICE -> "발송 결과 알림"
+            NotificationType.DELIVERY_FAILED_NOTICE -> "발송 실패 알림"
         }
     }
 
@@ -26,6 +27,7 @@ object NotificationMessageGenerator {
             NotificationType.DEPARTURE -> "${senderNickname}님이 출발했습니다."
             NotificationType.TERMS_UPDATE_NOTICE -> "이용약관이 업데이트되었습니다. 내용을 확인해 주세요."
             NotificationType.DELIVERY_RESULT_NOTICE -> "요청하신 발송 작업이 완료되었습니다."
+            NotificationType.DELIVERY_FAILED_NOTICE -> "요청하신 발송 작업이 실패했습니다. 잠시 후 다시 시도해 주세요."
         }
     }
 }

--- a/src/main/kotlin/com/kdongsu5509/support/config/RabbitMQConfig.kt
+++ b/src/main/kotlin/com/kdongsu5509/support/config/RabbitMQConfig.kt
@@ -33,6 +33,7 @@ class RabbitMQConfig {
         const val ROUTING_KEY_DEPARTURE_CONFIRMATION: String = "noti.service.location.departure"
         const val ROUTING_KEY_TERMS_UPDATE: String = "noti.service.terms.update"
         const val ROUTING_KEY_DELIVERY_RESULT: String = "noti.service.delivery.result"
+        const val ROUTING_KEY_DELIVERY_FAILED: String = "noti.service.delivery.failed"
 
         // ── Dead Letter Exchange / Queue ───────────────
         const val DLX_NAME: String = "imhere.noti.dlx"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,7 @@ spring:
       idle-timeout: 600000
       connection-timeout: 30000
       max-lifetime: 1800000
+      keepalive-time: 120000
 
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
@@ -185,7 +186,7 @@ management:
         otlp:
           # Production: send traces only to the alloy container on the same compose network.
           # Grafana Cloud credentials are handled by alloy, not by the app.
-          endpoint: http://alloy:4318/v1/traces
+          endpoint: http://alloy-container:4318/v1/traces
 
 logging:
   structured:

--- a/src/test/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/FriendNotificationConsumerTest.kt
+++ b/src/test/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/FriendNotificationConsumerTest.kt
@@ -7,6 +7,7 @@ import com.kdongsu5509.notifications.application.port.`in`.NotificationDispatche
 import com.kdongsu5509.notifications.application.port.`in`.NotificationEnqueueUseCase
 import com.kdongsu5509.notifications.application.service.MessageIdempotencyService
 import com.kdongsu5509.shared.notification.dto.NotificationPersonInfo
+import com.kdongsu5509.support.external.DiscordMessageSendPort
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -34,6 +35,9 @@ class FriendNotificationConsumerTest {
     @Mock
     private lateinit var notificationEnqueueUseCase: NotificationEnqueueUseCase
 
+    @Mock
+    private lateinit var discordMessageSendPort: DiscordMessageSendPort
+
     private lateinit var consumer: FriendNotificationConsumer
 
     @BeforeEach
@@ -41,7 +45,8 @@ class FriendNotificationConsumerTest {
         consumer = FriendNotificationConsumer(
             notificationDispatcherUseCase,
             messageIdempotencyService,
-            notificationEnqueueUseCase
+            notificationEnqueueUseCase,
+            discordMessageSendPort
         )
     }
 

--- a/src/test/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/ServiceNotificationConsumerTest.kt
+++ b/src/test/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/ServiceNotificationConsumerTest.kt
@@ -7,6 +7,7 @@ import com.kdongsu5509.notifications.application.port.`in`.NotificationDispatche
 import com.kdongsu5509.notifications.application.port.`in`.NotificationEnqueueUseCase
 import com.kdongsu5509.notifications.application.service.MessageIdempotencyService
 import com.kdongsu5509.shared.notification.dto.NotificationPersonInfo
+import com.kdongsu5509.support.external.DiscordMessageSendPort
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -34,6 +35,9 @@ class ServiceNotificationConsumerTest {
     @Mock
     private lateinit var notificationEnqueueUseCase: NotificationEnqueueUseCase
 
+    @Mock
+    private lateinit var discordMessageSendPort: DiscordMessageSendPort
+
     private lateinit var consumer: ServiceNotificationConsumer
 
     @BeforeEach
@@ -41,7 +45,8 @@ class ServiceNotificationConsumerTest {
         consumer = ServiceNotificationConsumer(
             notificationDispatcherUseCase,
             messageIdempotencyService,
-            notificationEnqueueUseCase
+            notificationEnqueueUseCase,
+            discordMessageSendPort
         )
     }
 
@@ -92,5 +97,24 @@ class ServiceNotificationConsumerTest {
             .hasMessage("Dispatch error")
 
         verify(messageIdempotencyService, never()).markAsProcessed(dto.messageId.toString())
+    }
+
+    @Test
+    @DisplayName("dispatch 실패 시 sender에게 FCM으로 발송 실패 알림을 큐에 등록한다")
+    fun receiveMessage_exception_notifiesSenderViaFcm() {
+        val dto = createDto()
+        whenever(messageIdempotencyService.isAlreadyProcessed(dto.messageId.toString())).thenReturn(false)
+        doThrow(RuntimeException("Dispatch error")).whenever(notificationDispatcherUseCase).dispatch(any<NotificationCommand>())
+
+        assertThatThrownBy { consumer.receiveMessage(dto) }
+            .isInstanceOf(RuntimeException::class.java)
+
+        verify(notificationEnqueueUseCase).enqueue(
+            org.mockito.kotlin.argThat {
+                type == NotificationType.DELIVERY_FAILED_NOTICE.name &&
+                    notificationMethod == com.kdongsu5509.notifications.domain.NotificationMethod.FCM &&
+                    targetIdentifier == dto.sender.email
+            }
+        )
     }
 }


### PR DESCRIPTION
- application.yaml: OTel exporter endpoint를 alloy-container(container_name)로 수정 (UnknownHostException: alloy)
- application.yaml: hikari keepalive-time 추가, idle 커넥션이 housekeeper 체크 전에 끊기는 문제 대응
- infra/alloy/alloy-config.alloy.template: prometheus scrape target을 옛 compose 별칭 dsko에서 iamhere-server-container로 수정 (scrape 항상 down)
- AbstractNotificationConsumer: 컨슈머(백그라운드 스레드) 실패 시 운영자용 Discord 알림 추가 (기존 5xx/4xx 알림 경로는 HTTP 요청 컨텍스트 필요해서 컨슈머 실패를 못 잡았음)
- NotificationType.DELIVERY_FAILED_NOTICE 추가: 발송 실패 시 sender에게 FCM으로도 알림, 무한루프 방지를 위해 메타 알림 타입끼리는 재귀 발행 안 함

closes #95 

## 누가 · 언제 · 어디서 · 무엇을 · 왜 · 어떻게

- [ ] 테스트
- [ ] Breaking change
