### PR TITLE
feat(fcm): split notification channels by type

### DIFF
--- a/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/dto/NotificationType.kt
+++ b/src/main/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/dto/NotificationType.kt
@@ -1,5 +1,7 @@
 package com.kdongsu5509.notifications.adapter.`in`.messageQueue.dto
 
+import com.google.firebase.messaging.AndroidConfig
+
 enum class NotificationType(val appPath: String) {
     FRIEND_REQUEST_RECEIVED("/contact/requests"),
     FRIEND_REQUEST_ACCEPTED("/friend/list"),
@@ -18,5 +20,22 @@ enum class NotificationType(val appPath: String) {
             DEPARTURE,
             ARRIVAL_CONFIRMATION
         )
+
+        fun fromName(name: String?): NotificationType? =
+            name?.let { runCatching { valueOf(it) }.getOrNull() }
     }
+
+    val androidChannelId: String
+        get() = when (this) {
+            ARRIVAL, ARRIVAL_CONFIRMATION, DEPARTURE -> "fcm_critical_channel"
+            FRIEND_REQUEST_RECEIVED, LOCATION_SHARE_RECEIVED -> "fcm_high_channel"
+            FRIEND_REQUEST_ACCEPTED, DELIVERY_FAILED_NOTICE -> "fcm_normal_channel"
+            TERMS_UPDATE_NOTICE, DELIVERY_RESULT_NOTICE -> "fcm_silent_channel"
+        }
+
+    val androidPriority: AndroidConfig.Priority
+        get() = when (this) {
+            TERMS_UPDATE_NOTICE, DELIVERY_RESULT_NOTICE -> AndroidConfig.Priority.NORMAL
+            else -> AndroidConfig.Priority.HIGH
+        }
 }

--- a/src/main/kotlin/com/kdongsu5509/notifications/adapter/out/firebase/FirebaseAdapter.kt
+++ b/src/main/kotlin/com/kdongsu5509/notifications/adapter/out/firebase/FirebaseAdapter.kt
@@ -1,6 +1,7 @@
 package com.kdongsu5509.notifications.adapter.out.firebase
 
 import com.google.firebase.messaging.*
+import com.kdongsu5509.notifications.adapter.`in`.messageQueue.dto.NotificationType
 import com.kdongsu5509.notifications.application.port.out.FirebasePort
 import com.kdongsu5509.support.exception.ImHereBaseException
 import com.kdongsu5509.support.exception.type.InternalServerException
@@ -57,7 +58,21 @@ class FirebaseAdapter(private val firebaseMessaging: FirebaseMessaging) : Fireba
         Message.builder()
             .setNotification(Notification.builder().setTitle(title).setBody(body).build())
             .putAllData(data)
+            .setAndroidConfig(createAndroidConfig(data))
             .setToken(token).build()
+
+    private fun createAndroidConfig(data: Map<String, String>): AndroidConfig {
+        val notificationType = NotificationType.fromName(data["type"]) ?: NotificationType.DELIVERY_RESULT_NOTICE
+
+        return AndroidConfig.builder()
+            .setPriority(notificationType.androidPriority)
+            .setNotification(
+                AndroidNotification.builder()
+                    .setChannelId(notificationType.androidChannelId)
+                    .build()
+            )
+            .build()
+    }
 
     private fun logAndThrow(exception: ImHereBaseException, ex: Exception): Nothing {
         log.error("[${exception.errorCode}] ${exception.message}", ex)

--- a/src/test/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/dto/NotificationTypeChannelPolicyTest.kt
+++ b/src/test/kotlin/com/kdongsu5509/notifications/adapter/in/messageQueue/dto/NotificationTypeChannelPolicyTest.kt
@@ -1,0 +1,37 @@
+package com.kdongsu5509.notifications.adapter.`in`.messageQueue.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class NotificationTypeChannelPolicyTest {
+
+    @Test
+    @DisplayName("도착/출발 알림은 critical 채널을 사용한다")
+    fun channelId_critical() {
+        assertThat(NotificationType.ARRIVAL.androidChannelId).isEqualTo("fcm_critical_channel")
+        assertThat(NotificationType.ARRIVAL_CONFIRMATION.androidChannelId).isEqualTo("fcm_critical_channel")
+        assertThat(NotificationType.DEPARTURE.androidChannelId).isEqualTo("fcm_critical_channel")
+    }
+
+    @Test
+    @DisplayName("친구 요청/위치 공유는 high 채널을 사용한다")
+    fun channelId_high() {
+        assertThat(NotificationType.FRIEND_REQUEST_RECEIVED.androidChannelId).isEqualTo("fcm_high_channel")
+        assertThat(NotificationType.LOCATION_SHARE_RECEIVED.androidChannelId).isEqualTo("fcm_high_channel")
+    }
+
+    @Test
+    @DisplayName("친구 수락/발송 실패는 normal 채널을 사용한다")
+    fun channelId_normal() {
+        assertThat(NotificationType.FRIEND_REQUEST_ACCEPTED.androidChannelId).isEqualTo("fcm_normal_channel")
+        assertThat(NotificationType.DELIVERY_FAILED_NOTICE.androidChannelId).isEqualTo("fcm_normal_channel")
+    }
+
+    @Test
+    @DisplayName("공지/발송 결과는 silent 채널을 사용한다")
+    fun channelId_silent() {
+        assertThat(NotificationType.TERMS_UPDATE_NOTICE.androidChannelId).isEqualTo("fcm_silent_channel")
+        assertThat(NotificationType.DELIVERY_RESULT_NOTICE.androidChannelId).isEqualTo("fcm_silent_channel")
+    }
+}


### PR DESCRIPTION
Closes #98\n\n- Map NotificationType to Android notification channels\n- Send channel/priority metadata with FCM payloads\n- Keep delivery-result notices quiet by policy\n- Add policy and adapter tests