### PR TITLE
feat(auth): harden admin ott ip checks

### DIFF
--- a/src/main/kotlin/com/kdongsu5509/auth/adapter/in/web/AdminWebController.kt
+++ b/src/main/kotlin/com/kdongsu5509/auth/adapter/in/web/AdminWebController.kt
@@ -27,6 +27,6 @@ class AdminWebController(
         return "admin/ott"
     }
 
-    @GetMapping("/admin")
+    @GetMapping("/admin", "/admin/")
     fun dashboard(): String = "admin/dashboard"
 }

--- a/src/main/kotlin/com/kdongsu5509/auth/security/ClientIpResolver.kt
+++ b/src/main/kotlin/com/kdongsu5509/auth/security/ClientIpResolver.kt
@@ -1,0 +1,36 @@
+package com.kdongsu5509.auth.security
+
+import jakarta.servlet.http.HttpServletRequest
+
+/**
+ * 신뢰 가능한 클라이언트 IP를 추출한다.
+ *
+ * 보안 핵심: nginx는 `proxy_set_header X-Real-IP $remote_addr`로 X-Real-IP를 항상 덮어쓰므로
+ * client가 직접 주입한 X-Real-IP는 무력화된다. 반면 X-Forwarded-For는
+ * `$proxy_add_x_forwarded_for`(append)로 전달되어 첫 요소를 공격자가 위조할 수 있다.
+ * 따라서 X-Real-IP를 최우선 신뢰하고, 부재 시(nginx 미경유)에만 XFF의 **마지막**
+ * 요소(= 직전 프록시가 append한 실제 peer)로 fallback 한다. XFF 첫 요소는 절대 신뢰하지 않는다.
+ */
+object ClientIpResolver {
+
+    private const val X_REAL_IP = "X-Real-IP"
+    private const val X_FORWARDED_FOR = "X-Forwarded-For"
+    private const val UNKNOWN = "unknown"
+
+    fun resolve(request: HttpServletRequest): String {
+        val realIp = request.getHeader(X_REAL_IP)
+        if (!realIp.isNullOrBlank() && !realIp.contains(UNKNOWN)) {
+            return realIp.trim()
+        }
+
+        val xff = request.getHeader(X_FORWARDED_FOR)
+        if (!xff.isNullOrBlank() && !xff.contains(UNKNOWN)) {
+            val lastHop = xff.split(",").map { it.trim() }.lastOrNull { it.isNotEmpty() }
+            if (!lastHop.isNullOrEmpty()) {
+                return lastHop
+            }
+        }
+
+        return request.remoteAddr
+    }
+}

--- a/src/main/kotlin/com/kdongsu5509/auth/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/kdongsu5509/auth/security/config/SecurityConfig.kt
@@ -75,7 +75,12 @@ class SecurityConfig(
         JdbcOneTimeTokenService(jdbcOperation)
 
     @Bean
-    fun ottIpFilterConfig(): OttIpFilterConfig {
+    fun ottIpFilterConfig(environment: org.springframework.core.env.Environment): OttIpFilterConfig {
+        // prod에서 admin.allowed-ips가 비어 있으면 IP allowlist가 무력화되므로
+        // 조용히 통과시키지 않고 startup을 실패시킨다(fail-closed).
+        if (environment.activeProfiles.contains("prod") && allowedIps.none { it.isNotBlank() }) {
+            throw IllegalStateException("prod 프로파일에는 admin.allowed-ips가 반드시 설정되어야 합니다.")
+        }
         return OttIpFilterConfig(adminId, "", allowedIps)
     }
 

--- a/src/main/kotlin/com/kdongsu5509/auth/security/filter/OttIpValidationFilter.kt
+++ b/src/main/kotlin/com/kdongsu5509/auth/security/filter/OttIpValidationFilter.kt
@@ -1,5 +1,6 @@
 package com.kdongsu5509.auth.security.filter
 
+import com.kdongsu5509.auth.security.ClientIpResolver
 import jakarta.servlet.Filter
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletRequest
@@ -15,12 +16,6 @@ class OttIpValidationFilter(
 
     private val log = LoggerFactory.getLogger(OttIpValidationFilter::class.java)
 
-    companion object {
-        private const val OTT_REQUEST_URL = "/admin/ott/request"
-        private const val X_FORWARDED_FOR = "X-Forwarded-For"
-        private const val X_REAL_IP = "X-Real-IP"
-    }
-
     override fun doFilter(
         request: ServletRequest,
         response: ServletResponse,
@@ -29,32 +24,17 @@ class OttIpValidationFilter(
         val httpRequest = request as HttpServletRequest
         val httpResponse = response as HttpServletResponse
 
-        if (shouldValidateIp(httpRequest)) {
-            val clientIp = extractClientIp(httpRequest)
-            if (!isIpAllowed(clientIp)) {
-                httpResponse.status = HttpStatus.FORBIDDEN.value()
-                httpResponse.contentType = "application/json"
-                httpResponse.writer.write("""{"error": "Forbidden"}""")
-                return
-            }
+        // 이 필터는 SecurityConfig의 admin 체인(/admin/**, /api/admin/**)에만 wiring되어 있으므로
+        // 도달한 모든 요청을 검사하면 admin 전 경로(로그인 페이지 포함)가 allowlist로 잠긴다.
+        val clientIp = ClientIpResolver.resolve(httpRequest)
+        if (!isIpAllowed(clientIp)) {
+            httpResponse.status = HttpStatus.FORBIDDEN.value()
+            httpResponse.contentType = "application/json"
+            httpResponse.writer.write("""{"error": "Forbidden"}""")
+            return
         }
 
         chain.doFilter(request, response)
-    }
-
-    private fun shouldValidateIp(request: HttpServletRequest): Boolean {
-        return request.requestURI == OTT_REQUEST_URL && request.method == "POST"
-    }
-
-    private fun extractClientIp(request: HttpServletRequest): String {
-        var ip = request.getHeader(X_FORWARDED_FOR)
-        if (ip.isNullOrEmpty() || ip.contains("unknown")) {
-            ip = request.getHeader(X_REAL_IP)
-        }
-        if (ip.isNullOrEmpty() || ip.contains("unknown")) {
-            ip = request.remoteAddr
-        }
-        return ip?.split(",")?.firstOrNull()?.trim() ?: request.remoteAddr
     }
 
     private fun isIpAllowed(clientIp: String): Boolean {

--- a/src/main/kotlin/com/kdongsu5509/auth/security/handler/ImHereOttSuccessHandler.kt
+++ b/src/main/kotlin/com/kdongsu5509/auth/security/handler/ImHereOttSuccessHandler.kt
@@ -1,6 +1,8 @@
 package com.kdongsu5509.auth.security.handler
 
-import com.kdongsu5509.shared.response.APIResponseSerializers
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.kdongsu5509.auth.security.ClientIpResolver
 import com.kdongsu5509.support.external.DiscordMessageDto
 import com.kdongsu5509.support.external.DiscordMessageSender
 import jakarta.servlet.http.HttpServletRequest
@@ -13,7 +15,7 @@ import org.springframework.stereotype.Component
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 @Component
 class ImHereOttSuccessHandler(
@@ -33,12 +35,19 @@ class ImHereOttSuccessHandler(
             > 해당 토큰을 사용하여 로그인을 완료해주세요.
         """
         private const val OTT_VALIDITY_MINUTES = 5L
+        private const val MAX_OTT_REQUESTS = 3
     }
 
-    private val ottRequestTracker = ConcurrentHashMap<String, OttRequestInfo>()
+    // Caffeine expireAfterWrite로 rate limit 윈도우(5분) 만료를 위임한다.
+    // 수동 시간 비교 불필요, eviction 자동.
+    private val ottRequestTracker: Cache<String, OttRequestInfo> =
+        Caffeine.newBuilder()
+            .expireAfterWrite(OTT_VALIDITY_MINUTES, TimeUnit.MINUTES)
+            .maximumSize(10_000)
+            .build()
 
     override fun handle(request: HttpServletRequest, response: HttpServletResponse, oneTimeToken: OneTimeToken) {
-        val clientIp = extractClientIp(request)
+        val clientIp = ClientIpResolver.resolve(request)
 
         if (!canIssueOtt(oneTimeToken.username, clientIp)) {
             response.status = HttpStatus.TOO_MANY_REQUESTS.value()
@@ -52,39 +61,20 @@ class ImHereOttSuccessHandler(
     }
 
     private fun canIssueOtt(username: String, clientIp: String): Boolean {
-        val now = Instant.now().toEpochMilli()
-        val requestInfo = ottRequestTracker[username]
+        // 만료는 캐시가 처리하므로, 존재하면 윈도우 내 요청이다.
+        val requestInfo = ottRequestTracker.getIfPresent(username)
 
         if (requestInfo == null) {
-            ottRequestTracker[username] = OttRequestInfo(now, clientIp, 1)
+            ottRequestTracker.put(username, OttRequestInfo(clientIp, 1))
             return true
         }
 
-        if (now - requestInfo.lastRequestTime > OTT_VALIDITY_MINUTES * 60 * 1000) {
-            ottRequestTracker[username] = OttRequestInfo(now, clientIp, 1)
-            return true
-        }
-
-        if (requestInfo.requestCount >= 3) {
+        if (requestInfo.requestCount >= MAX_OTT_REQUESTS) {
             return false
         }
 
-        ottRequestTracker[username] = requestInfo.copy(requestCount = requestInfo.requestCount + 1)
+        ottRequestTracker.put(username, requestInfo.copy(requestCount = requestInfo.requestCount + 1))
         return true
-    }
-
-    private fun extractClientIp(request: HttpServletRequest): String {
-        val xForwardedFor = request.getHeader("X-Forwarded-For")
-        if (!xForwardedFor.isNullOrEmpty() && !xForwardedFor.contains("unknown")) {
-            return xForwardedFor.split(",")[0].trim()
-        }
-
-        val xRealIp = request.getHeader("X-Real-IP")
-        if (!xRealIp.isNullOrEmpty() && !xRealIp.contains("unknown")) {
-            return xRealIp
-        }
-
-        return request.remoteAddr
     }
 
     private fun createOTTMessage(oneTimeToken: OneTimeToken, clientIp: String): String {
@@ -95,7 +85,6 @@ class ImHereOttSuccessHandler(
     }
 
     private data class OttRequestInfo(
-        val lastRequestTime: Long,
         val clientIp: String,
         val requestCount: Int
     )

--- a/src/test/kotlin/com/kdongsu5509/auth/security/ClientIpResolverTest.kt
+++ b/src/test/kotlin/com/kdongsu5509/auth/security/ClientIpResolverTest.kt
@@ -1,0 +1,61 @@
+package com.kdongsu5509.auth.security
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+
+class ClientIpResolverTest {
+
+    @Test
+    @DisplayName("X-Real-IP가 있으면 최우선으로 사용한다")
+    fun preferXRealIp() {
+        val request = MockHttpServletRequest()
+        request.addHeader("X-Real-IP", "203.0.113.10")
+        request.addHeader("X-Forwarded-For", "1.1.1.1, 203.0.113.10")
+        request.remoteAddr = "10.0.0.1"
+
+        assertThat(ClientIpResolver.resolve(request)).isEqualTo("203.0.113.10")
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For 첫 요소를 위조해도 X-Real-IP 기준이라 무력화된다")
+    fun spoofedXffFirstElementIsIgnored() {
+        val request = MockHttpServletRequest()
+        // 공격자가 허용 IP를 XFF 첫 요소에 주입, nginx가 실제 IP를 X-Real-IP로 덮어쓴 상황
+        request.addHeader("X-Forwarded-For", "39.118.242.177, 198.51.100.7")
+        request.addHeader("X-Real-IP", "198.51.100.7")
+        request.remoteAddr = "10.0.0.1"
+
+        assertThat(ClientIpResolver.resolve(request)).isEqualTo("198.51.100.7")
+    }
+
+    @Test
+    @DisplayName("X-Real-IP 부재 시 X-Forwarded-For의 마지막(append된 실제 peer) 요소를 사용한다")
+    fun fallbackToLastXffHop() {
+        val request = MockHttpServletRequest()
+        request.addHeader("X-Forwarded-For", "39.118.242.177, 198.51.100.7")
+        request.remoteAddr = "10.0.0.1"
+
+        assertThat(ClientIpResolver.resolve(request)).isEqualTo("198.51.100.7")
+    }
+
+    @Test
+    @DisplayName("프록시 헤더가 없으면 remoteAddr로 fallback 한다")
+    fun fallbackToRemoteAddr() {
+        val request = MockHttpServletRequest()
+        request.remoteAddr = "192.0.2.55"
+
+        assertThat(ClientIpResolver.resolve(request)).isEqualTo("192.0.2.55")
+    }
+
+    @Test
+    @DisplayName("X-Real-IP가 unknown이면 신뢰하지 않고 fallback 한다")
+    fun ignoreUnknownXRealIp() {
+        val request = MockHttpServletRequest()
+        request.addHeader("X-Real-IP", "unknown")
+        request.remoteAddr = "192.0.2.99"
+
+        assertThat(ClientIpResolver.resolve(request)).isEqualTo("192.0.2.99")
+    }
+}

--- a/src/test/kotlin/com/kdongsu5509/auth/security/filter/OttIpValidationFilterTest.kt
+++ b/src/test/kotlin/com/kdongsu5509/auth/security/filter/OttIpValidationFilterTest.kt
@@ -1,0 +1,62 @@
+package com.kdongsu5509.auth.security.filter
+
+import jakarta.servlet.FilterChain
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class OttIpValidationFilterTest {
+
+    private val allowedIp = "203.0.113.10"
+    private val config = OttIpFilterConfig(id = "admin", nickname = "", allowedIps = listOf(allowedIp))
+    private val filter = OttIpValidationFilter(config)
+
+    @Test
+    @DisplayName("허용 IP면 admin 모든 경로(로그인 페이지 포함)를 통과시킨다")
+    fun allowsAllAdminPathsForAllowedIp() {
+        val request = MockHttpServletRequest("GET", "/admin/login")
+        request.addHeader("X-Real-IP", allowedIp)
+        val response = MockHttpServletResponse()
+        val chain = mock(FilterChain::class.java)
+
+        filter.doFilter(request, response, chain)
+
+        verify(chain).doFilter(request, response)
+        assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+    }
+
+    @Test
+    @DisplayName("비허용 IP면 로그인 페이지조차 403으로 차단한다")
+    fun blocksLoginPageForDisallowedIp() {
+        val request = MockHttpServletRequest("GET", "/admin/login")
+        request.addHeader("X-Real-IP", "198.51.100.7")
+        val response = MockHttpServletResponse()
+        val chain = mock(FilterChain::class.java)
+
+        filter.doFilter(request, response, chain)
+
+        verify(chain, never()).doFilter(request, response)
+        assertThat(response.status).isEqualTo(HttpStatus.FORBIDDEN.value())
+    }
+
+    @Test
+    @DisplayName("XFF 첫 요소로 허용 IP를 위조해도 X-Real-IP 기준이라 차단된다")
+    fun blocksSpoofedXff() {
+        val request = MockHttpServletRequest("POST", "/admin/ott/request")
+        request.addHeader("X-Forwarded-For", "$allowedIp, 198.51.100.7")
+        request.addHeader("X-Real-IP", "198.51.100.7")
+        val response = MockHttpServletResponse()
+        val chain = mock(FilterChain::class.java)
+
+        filter.doFilter(request, response, chain)
+
+        verify(chain, never()).doFilter(request, response)
+        assertThat(response.status).isEqualTo(HttpStatus.FORBIDDEN.value())
+    }
+}

--- a/src/test/kotlin/com/kdongsu5509/auth/security/handler/ImHereOttSuccessHandlerTest.kt
+++ b/src/test/kotlin/com/kdongsu5509/auth/security/handler/ImHereOttSuccessHandlerTest.kt
@@ -43,4 +43,22 @@ class ImHereOttSuccessHandlerTest {
         assert(response.status == 302)
         assert(response.redirectedUrl == "/admin/ott?username=admin")
     }
+
+    @Test
+    @DisplayName("같은 관리자가 윈도우 내 4회째 요청하면 429로 차단한다")
+    fun rateLimit() {
+        repeat(3) {
+            val request = MockHttpServletRequest()
+            val response = MockHttpServletResponse()
+            val token: OneTimeToken = DefaultOneTimeToken("token-$it", "admin", Instant.now().plusSeconds(60))
+            handler.handle(request, response, token)
+            assert(response.status == 302)
+        }
+
+        val response = MockHttpServletResponse()
+        val token: OneTimeToken = DefaultOneTimeToken("token-4", "admin", Instant.now().plusSeconds(60))
+        handler.handle(MockHttpServletRequest(), response, token)
+
+        assert(response.status == 429)
+    }
 }


### PR DESCRIPTION
Closes #100\n\n- Extract trusted client IP resolution into a dedicated helper\n- Apply OTT IP validation across admin web/api paths\n- Fail closed when prod allowlist is missing\n- Add tests for client IP resolution, filter behavior, and OTT rate limiting