### PR TITLE
[Feature] F07/T19. 네이버 지도 API 서버 프록시

### DIFF
--- a/src/main/kotlin/com/kdongsu5509/maps/NaverMapProxyClient.kt
+++ b/src/main/kotlin/com/kdongsu5509/maps/NaverMapProxyClient.kt
@@ -1,0 +1,123 @@
+package com.kdongsu5509.maps
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.ResourceAccessException
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientException
+import java.time.Duration
+
+@Component
+class NaverMapProxyClient(
+    restClientBuilder: RestClient.Builder,
+    @Value("\${NAVER_MAP_CLIENT_ID:}") private val mapClientId: String,
+    @Value("\${NAVER_MAP_CLIENT_SECRET:}") private val mapClientSecret: String,
+    @Value("\${NAVER_SEARCH_CLIENT_ID:}") private val searchClientId: String,
+    @Value("\${NAVER_SEARCH_CLIENT_SECRET:}") private val searchClientSecret: String,
+) {
+    private val mapsClient = restClientBuilder.clone()
+        .baseUrl(MAPS_BASE_URL)
+        .requestFactory(requestFactory())
+        .defaultHeader("x-ncp-apigw-api-key-id", mapClientId)
+        .defaultHeader("x-ncp-apigw-api-key", mapClientSecret)
+        .build()
+
+    private val searchClient = restClientBuilder.clone()
+        .baseUrl(SEARCH_BASE_URL)
+        .requestFactory(requestFactory())
+        .defaultHeader("X-Naver-Client-Id", searchClientId)
+        .defaultHeader("X-Naver-Client-Secret", searchClientSecret)
+        .build()
+
+    fun geocode(query: String): Map<String, Any?> {
+        requireCredentials(mapClientId, mapClientSecret)
+        return execute {
+            mapsClient.get()
+                .uri { it.path(GEOCODE_PATH).queryParam("query", query).build() }
+                .header(HttpHeaders.ACCEPT, "application/json")
+                .retrieve()
+                .body(Map::class.java)
+        }
+    }
+
+    fun reverseGeocode(latitude: Double, longitude: Double): Map<String, Any?> {
+        requireCredentials(mapClientId, mapClientSecret)
+        return execute {
+            mapsClient.get()
+                .uri {
+                    it.path(REVERSE_GEOCODE_PATH)
+                        .queryParam("coords", "$longitude,$latitude")
+                        .queryParam("orders", "roadaddr,addr")
+                        .queryParam("output", "json")
+                        .build()
+                }
+                .header(HttpHeaders.ACCEPT, "application/json")
+                .retrieve()
+                .body(Map::class.java)
+        }
+    }
+
+    fun searchLocal(query: String, display: Int): Map<String, Any?> {
+        requireCredentials(searchClientId, searchClientSecret)
+        return execute {
+            searchClient.get()
+                .uri {
+                    it.path(LOCAL_SEARCH_PATH)
+                        .queryParam("query", query)
+                        .queryParam("display", display)
+                        .build()
+                }
+                .header(HttpHeaders.ACCEPT, "application/json")
+                .retrieve()
+                .body(Map::class.java)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun execute(block: () -> Map<*, *>?): Map<String, Any?> {
+        try {
+            return block()?.entries?.associate { it.key.toString() to it.value }
+                ?: emptyMap()
+        } catch (error: ResourceAccessException) {
+            throw NaverMapProxyException(
+                HttpStatus.GATEWAY_TIMEOUT,
+                "MAP-504",
+                "지도 서비스 응답 시간이 초과되었습니다.",
+                error,
+            )
+        } catch (error: RestClientException) {
+            throw NaverMapProxyException(
+                HttpStatus.BAD_GATEWAY,
+                "MAP-502",
+                "지도 서비스에 연결할 수 없습니다.",
+                error,
+            )
+        }
+    }
+
+    private fun requireCredentials(clientId: String, secret: String) {
+        if (clientId.isBlank() || secret.isBlank()) {
+            throw NaverMapProxyException(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "MAP-503",
+                "지도 서비스 설정을 확인해 주세요.",
+            )
+        }
+    }
+
+    private fun requestFactory() = SimpleClientHttpRequestFactory().apply {
+        setConnectTimeout(Duration.ofSeconds(3))
+        setReadTimeout(Duration.ofSeconds(5))
+    }
+
+    companion object {
+        private const val MAPS_BASE_URL = "https://maps.apigw.ntruss.com"
+        private const val SEARCH_BASE_URL = "https://openapi.naver.com"
+        private const val GEOCODE_PATH = "/map-geocode/v2/geocode"
+        private const val REVERSE_GEOCODE_PATH = "/map-reversegeocode/v2/gc"
+        private const val LOCAL_SEARCH_PATH = "/v1/search/local.json"
+    }
+}

--- a/src/main/kotlin/com/kdongsu5509/maps/NaverMapProxyController.kt
+++ b/src/main/kotlin/com/kdongsu5509/maps/NaverMapProxyController.kt
@@ -1,0 +1,49 @@
+package com.kdongsu5509.maps
+
+import com.kdongsu5509.shared.response.ApiResponse
+import jakarta.validation.constraints.DecimalMax
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Validated
+@RestController
+@RequestMapping("/api/maps")
+class NaverMapProxyController(
+    private val service: NaverMapProxyService,
+) {
+    @GetMapping("/geocode")
+    fun geocode(
+        @RequestParam @Size(min = 1, max = 200) query: String,
+    ): ApiResponse<Map<String, Any?>> =
+        ApiResponse.success(service.geocode(query))
+
+    @GetMapping("/reverse-geocode")
+    fun reverseGeocode(
+        @RequestParam @DecimalMin("-90.0") @DecimalMax("90.0") latitude: Double,
+        @RequestParam @DecimalMin("-180.0") @DecimalMax("180.0") longitude: Double,
+    ): ApiResponse<Map<String, Any?>> =
+        ApiResponse.success(service.reverseGeocode(latitude, longitude))
+
+    @GetMapping("/local-search")
+    fun localSearch(
+        @RequestParam @Size(min = 1, max = 100) query: String,
+        @RequestParam(defaultValue = "5") @Min(1) @Max(10) display: Int,
+    ): ApiResponse<Map<String, Any?>> =
+        ApiResponse.success(service.searchLocal(query, display))
+
+    @ExceptionHandler(NaverMapProxyException::class)
+    fun handleProxyException(
+        error: NaverMapProxyException,
+    ): ResponseEntity<ApiResponse<Unit>> =
+        ResponseEntity.status(error.status)
+            .body(ApiResponse.fail(error.code, error.message))
+}

--- a/src/main/kotlin/com/kdongsu5509/maps/NaverMapProxyException.kt
+++ b/src/main/kotlin/com/kdongsu5509/maps/NaverMapProxyException.kt
@@ -1,0 +1,10 @@
+package com.kdongsu5509.maps
+
+import org.springframework.http.HttpStatus
+
+class NaverMapProxyException(
+    val status: HttpStatus,
+    val code: String,
+    override val message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/src/main/kotlin/com/kdongsu5509/maps/NaverMapProxyService.kt
+++ b/src/main/kotlin/com/kdongsu5509/maps/NaverMapProxyService.kt
@@ -1,0 +1,21 @@
+package com.kdongsu5509.maps
+
+import org.springframework.stereotype.Service
+
+@Service
+class NaverMapProxyService(
+    private val client: NaverMapProxyClient,
+) {
+    fun geocode(query: String): Map<String, Any?> =
+        NaverMapResponseSanitizer.geocode(client.geocode(query.trim()))
+
+    fun reverseGeocode(latitude: Double, longitude: Double): Map<String, Any?> =
+        NaverMapResponseSanitizer.reverseGeocode(
+            client.reverseGeocode(latitude, longitude),
+        )
+
+    fun searchLocal(query: String, display: Int): Map<String, Any?> =
+        NaverMapResponseSanitizer.localSearch(
+            client.searchLocal(query.trim(), display),
+        )
+}

--- a/src/main/kotlin/com/kdongsu5509/maps/NaverMapResponseSanitizer.kt
+++ b/src/main/kotlin/com/kdongsu5509/maps/NaverMapResponseSanitizer.kt
@@ -1,0 +1,72 @@
+package com.kdongsu5509.maps
+
+object NaverMapResponseSanitizer {
+    fun geocode(raw: Map<String, Any?>): Map<String, Any?> =
+        mapOf(
+            "addresses" to raw.listOfMaps("addresses").map {
+                it.only(
+                    "roadAddress",
+                    "jibunAddress",
+                    "englishAddress",
+                    "x",
+                    "y",
+                    "distance",
+                )
+            },
+        )
+
+    fun reverseGeocode(raw: Map<String, Any?>): Map<String, Any?> =
+        mapOf(
+            "results" to raw.listOfMaps("results").map {
+                mapOf(
+                    "name" to it["name"],
+                    "region" to (it["region"] as? Map<*, *>)?.sanitisedRegion(),
+                    "land" to (it["land"] as? Map<*, *>)?.only(
+                        "type",
+                        "name",
+                        "number1",
+                        "number2",
+                        "addition0",
+                        "addition1",
+                        "addition2",
+                        "addition3",
+                        "addition4",
+                    ),
+                )
+            },
+        )
+
+    fun localSearch(raw: Map<String, Any?>): Map<String, Any?> =
+        mapOf(
+            "items" to raw.listOfMaps("items").map {
+                it.only(
+                    "title",
+                    "link",
+                    "category",
+                    "description",
+                    "telephone",
+                    "address",
+                    "roadAddress",
+                    "mapx",
+                    "mapy",
+                )
+            },
+        )
+
+    private fun Map<String, Any?>.listOfMaps(key: String): List<Map<String, Any?>> =
+        (this[key] as? List<*>).orEmpty().mapNotNull { value ->
+            (value as? Map<*, *>)?.entries?.associate {
+                it.key.toString() to it.value
+            }
+        }
+
+    private fun Map<*, *>.only(vararg keys: String): Map<String, Any?> =
+        keys.associateWith { this[it] }.filterValues { it != null }
+
+    private fun Map<*, *>.sanitisedRegion(): Map<String, Any?> =
+        listOf("area0", "area1", "area2", "area3", "area4")
+            .associateWith { area ->
+                (this[area] as? Map<*, *>)?.only("name", "coords")
+            }
+            .filterValues { it != null }
+}

--- a/src/test/kotlin/com/kdongsu5509/maps/NaverMapResponseSanitizerTest.kt
+++ b/src/test/kotlin/com/kdongsu5509/maps/NaverMapResponseSanitizerTest.kt
@@ -1,0 +1,44 @@
+package com.kdongsu5509.maps
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class NaverMapResponseSanitizerTest {
+    @Test
+    fun `geocode keeps only client fields`() {
+        val result = NaverMapResponseSanitizer.geocode(
+            mapOf(
+                "addresses" to listOf(
+                    mapOf(
+                        "roadAddress" to "서울시",
+                        "x" to "127.0",
+                        "y" to "37.0",
+                        "secret" to "must-not-leak",
+                    ),
+                ),
+                "apiKey" to "must-not-leak",
+            ),
+        )
+
+        assertThat(result.toString()).contains("서울시")
+        assertThat(result.toString()).doesNotContain("secret", "apiKey")
+    }
+
+    @Test
+    fun `local search strips unapproved upstream fields`() {
+        val result = NaverMapResponseSanitizer.localSearch(
+            mapOf(
+                "items" to listOf(
+                    mapOf(
+                        "title" to "카페",
+                        "roadAddress" to "서울시",
+                        "unapproved" to "hidden",
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(result.toString()).contains("카페")
+        assertThat(result.toString()).doesNotContain("unapproved", "hidden")
+    }
+}


### PR DESCRIPTION
## 연결 이슈

Closes #108

## 변경 목적

F07/T19 네이버 지오코딩·역지오코딩·지역검색을 서버 프록시로 옮겨 웹에 secret이 노출되지 않게 합니다.

## 주요 변경 사항

- 고정 allowlist 호스트/경로 3종 RestClient
- NCP 지도 키와 검색 키를 서버 환경변수에서만 주입
- connect 3초/read 5초 timeout, 502/503/504 envelope 변환
- 인증된 `/api/maps/*` 엔드포인트와 입력 범위 검증
- 클라이언트 사용 필드만 남기는 응답 sanitizer

## 완료 조건 확인

- [x] 프록시 3종
- [x] 서버 환경변수 자격증명
- [x] ImHere envelope와 기존 authenticated API 정책
- [x] 고정 외부 allowlist와 timeout
- [x] 응답 필드 화이트리스트

## 검증

```text
./gradlew test --tests com.kdongsu5509.maps.NaverMapResponseSanitizerTest
결과: 원격 main의 기존 약관 리팩터링 누락 참조(AllowPendingUser, TermCatalog, TermFact)로 compileKotlin 단계에서 선행 실패. 신규 maps 테스트 도달 전 중단.
```

## 위험 및 호환성

- 필요한 환경변수: NAVER_MAP_CLIENT_ID, NAVER_MAP_CLIENT_SECRET, NAVER_SEARCH_CLIENT_ID, NAVER_SEARCH_CLIENT_SECRET
- 자격증명 누락 시 503, 외부 timeout 시 504, 기타 외부 장애 시 502를 반환합니다.
- 외부 호출량 캐싱/레이트리밋은 운영 트래픽 검토 후 후속 적용이 필요합니다.